### PR TITLE
Fix: prevent nesting details blocks

### DIFF
--- a/lib/build-parent-toc.js
+++ b/lib/build-parent-toc.js
@@ -104,8 +104,9 @@ function generateReadmeChange(folder, toc) {
 
   const path = `${folder}/README.md`;
   if (fs.existsSync(path)) {
-    const data = fs.readFileSync(path, 'utf8')
-      .replace(/(Table of Contents\n).*(<!-- END)/gms, `${detailsOpenBlock}\n$1\n${toc}\n${detailsCloseBlock}\n$2`);
+    const regex = new RegExp(`(${detailsOpenBlock}\n)?(Table of Contents\n).*(<!-- END)`, 'gms');
+    const file = fs.readFileSync(path, 'utf8')
+    const data = file.replace(regex, `${detailsOpenBlock}\n$2\n${toc}\n${detailsCloseBlock}\n$3`);
 
     return [{ path, data }]
   } else {

--- a/test/build-parent-toc.js
+++ b/test/build-parent-toc.js
@@ -83,3 +83,70 @@ test('\nBuild Parent Toc', function (t) {
   t.deepEqual(true, true)
   t.end()
 })
+
+test('\nBuild Parent Toc with details', function (t) {
+  const { changeList } = processFolder({
+    folder: 'test/fixtures/top-level-folder-with-details'
+  });
+
+  assertPathChanges({
+    t,
+    changeList,
+    expectations: [
+      {
+        expectedPath: 'test/fixtures/top-level-folder-with-details/mid-level-folder/low-level-folder/README.md',
+        expectedData: [
+          '<!-- START doctoc generated TOC please keep comment here to allow auto update -->',
+          '<!-- DON\'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->',
+          '<details><summary>Full Table of Contents</summary>',
+          '',
+          'Table of Contents',
+          '',
+          '- [This is a test document with a number](./test_file.20200412.md#this-is-a-test-document-with-a-number)',
+          '- [This is a test document](./test_file.md#this-is-a-test-document)',
+          '',
+          '</details>',
+          '<!-- END doctoc generated TOC please keep comment here to allow auto update -->',
+        ].join('\n'),
+      },
+      {
+        expectedPath: 'test/fixtures/top-level-folder-with-details/mid-level-folder/README.md',
+        expectedData: [
+          '<!-- START doctoc generated TOC please keep comment here to allow auto update -->',
+          '<!-- DON\'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->',
+          '<details><summary>Full Table of Contents</summary>',
+          '',
+          'Table of Contents',
+          '',
+          '- [This is a test document with a number](./low-level-folder/test_file.20200412.md#this-is-a-test-document-with-a-number)',
+          '- [This is a test document](./low-level-folder/test_file.md#this-is-a-test-document)',
+          '',
+          '</details>',
+          '<!-- END doctoc generated TOC please keep comment here to allow auto update -->',
+        ].join('\n'),
+      },
+      {
+        expectedPath: 'test/fixtures/top-level-folder-with-details/README.md',
+        expectedData: [
+          '<!-- START doctoc generated TOC please keep comment here to allow auto update -->',
+          '<!-- DON\'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->',
+          '<details><summary>Full Table of Contents</summary>',
+          '',
+          'Table of Contents',
+          '',
+          '- [Top-level README](#top-level-readme)',
+          '- [This is a test document with a number](./mid-level-folder/low-level-folder/test_file.20200412.md#this-is-a-test-document-with-a-number)',
+          '- [This is a test document](./mid-level-folder/low-level-folder/test_file.md#this-is-a-test-document)',
+          '',
+          '</details>',
+          '<!-- END doctoc generated TOC please keep comment here to allow auto update -->',
+          '',
+          '# Top-level README',
+        ].join('\n'),
+      },
+    ]
+  })
+
+  t.deepEqual(true, true)
+  t.end()
+})

--- a/test/fixtures/top-level-folder-with-details/README.md
+++ b/test/fixtures/top-level-folder-with-details/README.md
@@ -1,0 +1,14 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+<details><summary>Full Table of Contents</summary>
+
+Table of Contents
+
+- [Top-level README](#top-level-readme)
+- [This is a test document with a number](./mid-level-folder/low-level-folder/test_file.20200412.md#this-is-a-test-document-with-a-number)
+- [This is a test document](./mid-level-folder/low-level-folder/test_file.md#this-is-a-test-document)
+
+</details>
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# Top-level README

--- a/test/fixtures/top-level-folder-with-details/mid-level-folder/README.md
+++ b/test/fixtures/top-level-folder-with-details/mid-level-folder/README.md
@@ -1,0 +1,11 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+<details><summary>Full Table of Contents</summary>
+
+Table of Contents
+
+- [This is a test document with a number](./low-level-folder/test_file.20200412.md#this-is-a-test-document-with-a-number)
+- [This is a test document](./low-level-folder/test_file.md#this-is-a-test-document)
+
+</details>
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->

--- a/test/fixtures/top-level-folder-with-details/mid-level-folder/low-level-folder/README.md
+++ b/test/fixtures/top-level-folder-with-details/mid-level-folder/low-level-folder/README.md
@@ -1,0 +1,11 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+<details><summary>Full Table of Contents</summary>
+
+Table of Contents
+
+- [This is a test document with a number](./test_file.20200412.md#this-is-a-test-document-with-a-number)
+- [This is a test document](./test_file.md#this-is-a-test-document)
+
+</details>
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->

--- a/test/fixtures/top-level-folder-with-details/mid-level-folder/low-level-folder/test_file.20200412.md
+++ b/test/fixtures/top-level-folder-with-details/mid-level-folder/low-level-folder/test_file.20200412.md
@@ -1,0 +1,10 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+Table of Contents
+
+- [This is a test document with a number](#this-is-a-test-document-with-a-number)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+
+# This is a test document with a number

--- a/test/fixtures/top-level-folder-with-details/mid-level-folder/low-level-folder/test_file.md
+++ b/test/fixtures/top-level-folder-with-details/mid-level-folder/low-level-folder/test_file.md
@@ -1,0 +1,1 @@
+# This is a test document


### PR DESCRIPTION
The code to put parent READMEs into a `<details/>` block was nesting them on multiple runs. This adds tests and fixes it.