### PR TITLE
Remove trailing spaces within html comments

### DIFF
--- a/lib/transform.js
+++ b/lib/transform.js
@@ -6,9 +6,9 @@ var _             = require('underscore')
   , getHtmlHeaders = require('./get-html-headers')
   , md            = require('@textlint/markdown-to-ast');
 
-var start = '<!-- START doctoc generated TOC please keep comment here to allow auto update -->\n' +
-            '<!-- DON\'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->'
-  , end   = '<!-- END doctoc generated TOC please keep comment here to allow auto update -->'
+var start = '<!-- START doctoc generated TOC please keep comment here to allow auto update-->\n' +
+            '<!-- DON\'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE-->'
+  , end   = '<!-- END doctoc generated TOC please keep comment here to allow auto update-->'
 
 function matchesStart(line) {
   return (/<!-- START doctoc /).test(line);


### PR DESCRIPTION
This is due to a quirk in the way markdownlint-cli2 will handle line counts when these trailing spaces are present

https://joinroot.slack.com/archives/CQK9TR718/p1622131211022600?thread_ts=1621442433.003500&cid=CQK9TR718